### PR TITLE
Cannot drag sorted column

### DIFF
--- a/src/fr/mikrosimage/gwt/client/ResizableHeader.java
+++ b/src/fr/mikrosimage/gwt/client/ResizableHeader.java
@@ -251,7 +251,10 @@ public abstract class ResizableHeader<T> extends Header<String> {
             this.dragCallback = dragCallback;
             final int clientX = event.getClientX();
             columnWidth = target.getOffsetWidth();
-            final Element tr = target.getParentElement();
+            Element tr = target.getParentElement();
+            while (!tr.getNodeName().equals("TR")) {
+            	tr = tr.getParentElement();
+            }
             final int columns = tr.getChildCount();
             columnXPositions = new int[columns + 1];
             columnXPositions[0] = tr.getAbsoluteLeft();


### PR DESCRIPTION
Fixed bug with dragging sortable columns.  After a column was sorted, it could not be dragged to the right.  It was possible to drag a column to the left of the sorted column; if the sorted column was subsequently dragged back to the left of the unsorted one, the sorted column would replace the unsorted column and there would be duplicate columns in the grid.

When the column is sorted, GWT inserts a div element into the table header, so getting the parent of the target element is not the table row.  I simply changed the code that finds the table row to traverse the DOM until the parent tr is found.
